### PR TITLE
Feature: persisted log of deliveries

### DIFF
--- a/app/controllers/api/v1/deliveries_controller.rb
+++ b/app/controllers/api/v1/deliveries_controller.rb
@@ -1,0 +1,2 @@
+class Api::V1::DeliveriesController < ApplicationController
+end

--- a/app/models/delivery.rb
+++ b/app/models/delivery.rb
@@ -9,7 +9,6 @@ class Delivery < ApplicationRecord
   }
 
   validates :response_status_code, numericality: {
-    greater_than_or_equal_to: 100,
     less_than_or_equal_to: 599,
     only_integer: true,
     allow_blank: true

--- a/app/models/delivery.rb
+++ b/app/models/delivery.rb
@@ -1,0 +1,28 @@
+class Delivery < ApplicationRecord
+  # associations
+  belongs_to :webhook
+
+  # validation
+  validates :status, inclusion: {
+    allow_blank: false,
+    in: %w(delivered errored timed_out)
+  }
+
+  validates :response_status_code, numericality: {
+    greater_than_or_equal_to: 100,
+    less_than_or_equal_to: 599,
+    only_integer: true,
+    allow_blank: true
+  }
+
+  validates :response_time_ms, numericality: {
+    greater_than_or_equal_to: 0,
+    only_integer: true,
+    allow_blank: true
+  }
+
+  # prevent modification once saved
+  def readonly?
+    persisted?
+  end
+end

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -6,7 +6,7 @@ class Webhook < ApplicationRecord
   attr_readonly :identifier, :url, :headers, :body
 
   # validation
-  validates :identifier, :url, :body, presence: true
+  validates :identifier, :url, presence: true
 
   # override save to allow for idempotent save
   def save(*)

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -1,4 +1,7 @@
 class Webhook < ApplicationRecord
+  # associations
+  has_many :deliveries
+
   # core webhook data cannot be modified once created
   attr_readonly :identifier, :url, :headers, :body
 

--- a/app/resources/api/v1/delivery_resource.rb
+++ b/app/resources/api/v1/delivery_resource.rb
@@ -1,0 +1,10 @@
+class Api::V1::DeliveryResource < JSONAPI::Resource
+  # cannot be modified by the API
+  immutable
+
+  attributes :status, :response_time_ms, :response_status_code,
+    :response_headers, :response_body
+
+  # associations
+  belongs_to :webhook
+end

--- a/app/resources/api/v1/webhook_resource.rb
+++ b/app/resources/api/v1/webhook_resource.rb
@@ -1,3 +1,6 @@
 class Api::V1::WebhookResource < JSONAPI::Resource
   attributes :identifier, :url, :headers, :body
+
+  # associations
+  has_many :deliveries
 end

--- a/app/services/deliver_webhook.rb
+++ b/app/services/deliver_webhook.rb
@@ -1,6 +1,7 @@
 require 'typhoeus'
 
-class DeliverWebhook
+# this module performs the transmission of a HTTP call
+module DeliverWebhook
   def self.call(url:, headers:, body:, timeout: 5, username: nil, password: nil)
     # if we have HTTP Basic Auth username / password, pass them
     if username || password

--- a/app/services/record_webhook.rb
+++ b/app/services/record_webhook.rb
@@ -17,9 +17,7 @@ module RecordWebhook
     delivery.save!
   end
 
-  private
-
-  def self.record_response_into_delivery(response, delivery)
+  private_class_method def self.record_response_into_delivery(response, delivery)
     delivery.response_time_ms     = ((response.time || 0) * 1000).to_i
     delivery.response_status_code = response.code
     delivery.response_headers     = response.headers

--- a/app/services/record_webhook.rb
+++ b/app/services/record_webhook.rb
@@ -17,7 +17,7 @@ module RecordWebhook
       end
     end
 
-  rescue Net::OpenTimeout, Net::ReadTimeout => ex
+  rescue Net::OpenTimeout, Net::ReadTimeout
     delivery.status = 'errored'
 
   # we should always save, even if an exception occured

--- a/app/services/record_webhook.rb
+++ b/app/services/record_webhook.rb
@@ -11,7 +11,14 @@ module RecordWebhook
       delivery.response_headers     = response.headers
       delivery.response_body        = response.body
       delivery.status               = 'delivered'
+
+      if response.timed_out?
+        delivery.status = 'timed_out'
+      end
     end
+
+  rescue Net::OpenTimeout, Net::ReadTimeout => ex
+    delivery.status = 'errored'
 
   # we should always save, even if an exception occured
   ensure

--- a/app/services/record_webhook.rb
+++ b/app/services/record_webhook.rb
@@ -6,15 +6,7 @@ module RecordWebhook
 
     # perform the request and record the response
     block.yield.tap do |response|
-      delivery.response_time_ms     = ((response.time || 0) * 1000).to_i
-      delivery.response_status_code = response.code
-      delivery.response_headers     = response.headers
-      delivery.response_body        = response.body
-      delivery.status               = 'delivered'
-
-      if response.timed_out?
-        delivery.status = 'timed_out'
-      end
+      record_response_into_delivery(response, delivery)
     end
 
   rescue Net::OpenTimeout, Net::ReadTimeout
@@ -23,5 +15,19 @@ module RecordWebhook
   # we should always save, even if an exception occured
   ensure
     delivery.save!
+  end
+
+  private
+
+  def self.record_response_into_delivery(response, delivery)
+    delivery.response_time_ms     = ((response.time || 0) * 1000).to_i
+    delivery.response_status_code = response.code
+    delivery.response_headers     = response.headers
+    delivery.response_body        = response.body
+    delivery.status               = 'delivered'
+
+    if response.timed_out?
+      delivery.status = 'timed_out'
+    end
   end
 end

--- a/app/services/subscribe_global_listeners.rb
+++ b/app/services/subscribe_global_listeners.rb
@@ -1,6 +1,6 @@
 require 'wisper'
 
-class SubscribeGlobalListeners
+module SubscribeGlobalListeners
   def self.call(&block)
     Wisper.subscribe(WebhookCreationListener, &block)
   end

--- a/app/workers/webhook_delivery_worker.rb
+++ b/app/workers/webhook_delivery_worker.rb
@@ -4,15 +4,17 @@ class WebhookDeliveryWorker
   include Sidekiq::Worker
   sidekiq_options queue: 'webhook_delivery', retry: 3
 
-  def perform(webhook_id, delivery_service: DeliverWebhook)
+  def perform(webhook_id, delivery_service: DeliverWebhook, record_service: RecordWebhook)
     # load the record from the database
     webhook = Webhook.find(webhook_id)
     # make the HTTP call
-    response = delivery_service.call({
-      url: webhook.url,
-      headers: webhook.headers,
-      body: webhook.body
-    })
+    response = record_service.call(webhook) do
+      delivery_service.call({
+        url: webhook.url,
+        headers: webhook.headers,
+        body: webhook.body
+      })
+    end
     # return true or false to requeue failures
     response.success?
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
-      jsonapi_resources :webhooks, except: [:update, :destroy]
+      jsonapi_resources :webhooks, except: [:update, :destroy] do
+        jsonapi_resources :deliveries
+      end
     end
   end
 end

--- a/db/migrate/20170206200008_create_deliveries.rb
+++ b/db/migrate/20170206200008_create_deliveries.rb
@@ -1,0 +1,15 @@
+class CreateDeliveries < ActiveRecord::Migration[5.0]
+  def change
+    create_table :deliveries do |t|
+      t.string  :status, null: false
+
+      t.integer :response_time_ms
+      t.integer :response_status_code
+      t.jsonb   :response_headers
+      t.text    :response_body
+
+      t.belongs_to :webhook, foreign_key: true
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170204111716) do
+ActiveRecord::Schema.define(version: 20170206200008) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "deliveries", force: :cascade do |t|
+    t.string   "status",               null: false
+    t.integer  "response_time_ms"
+    t.integer  "response_status_code"
+    t.jsonb    "response_headers"
+    t.text     "response_body"
+    t.integer  "webhook_id"
+    t.datetime "created_at",           null: false
+    t.datetime "updated_at",           null: false
+    t.index ["webhook_id"], name: "index_deliveries_on_webhook_id", using: :btree
+  end
 
   create_table "webhooks", force: :cascade do |t|
     t.uuid     "identifier",              null: false
@@ -26,4 +38,5 @@ ActiveRecord::Schema.define(version: 20170204111716) do
     t.index ["url"], name: "index_webhooks_on_url", using: :btree
   end
 
+  add_foreign_key "deliveries", "webhooks"
 end

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,6 @@
 The HTTP interface for this application is a [JSONAPI](http://jsonapi.org/)-compliant RESTful API. You should use a compliant client, such as [json_api_client](https://github.com/chingor13/json_api_client) to make integration as simple as possible.
 
-Currently, there is no security and only a single resource exists: webhooks.
+Currently, there is no security and only a two resources exist: webhooks and deliveries.
 
 ### Webhooks
 
@@ -50,3 +50,37 @@ Deliveries are attempted 3 times before the background queue will give up.
   }
 }
 ```
+
+### Deliveries
+
+Note: deliveries are read-only, you cannot even create them as the resource is designed to simply report on the status of webhook delivery attempts made from the background queues.
+
+#### Example Object
+
+```json
+{
+  "id": 1,
+  "type": "deliveries",
+  "attributes": {
+    "status": "delivered",
+    "response_time_ms": 103,
+    "response_status_code": 200,
+    "response_headers": {
+      "Content-Type": "text/plain"
+    },
+    "response_body": "Success!"
+  }
+}
+```
+
+#### Index
+
+`GET /api/v1/webhooks/:webhook_id/deliveries`
+
+This index provides a list of all deliveries for the given webhook's id.
+
+#### Show
+
+`GET /api/v1/webhooks/:webhook_id/deliveries/:id`
+
+This view will return the attributes of a single delivery.

--- a/spec/integration/deliveries_api_v1_spec.rb
+++ b/spec/integration/deliveries_api_v1_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+require 'securerandom'
+
+RSpec.describe 'Deliveries API v1', type: :api do
+  specify 'listing the deliveries of a given webhook' do
+    # Prepare
+    stub_request(:post, 'example.com').to_return(status: 200)
+
+    # Execute
+    webhook = TestModels::Webhook.create({
+      identifier: SecureRandom.uuid,
+      url: 'http://example.com/',
+      headers: {},
+      body: ''
+    })
+
+    WebhookDeliveryWorker.drain
+
+    # Verify
+    expect(webhook).to be_persisted
+    expect(webhook.deliveries.size).to eq(1)
+    expect(webhook.deliveries.first).to be_kind_of(TestModels::Delivery)
+  end
+end

--- a/spec/services/record_webhook_spec.rb
+++ b/spec/services/record_webhook_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+require 'typhoeus'
+
+RSpec.describe RecordWebhook do
+  context 'with a successful response' do
+    it 'should record a status of `delivered`', sidekiq_mode: :inline do
+      # Prepare
+      stub_request(:post, 'example.com').to_return(status: 200)
+
+      webhook = Webhook.create!({
+        identifier: SecureRandom.uuid,
+        url: 'http://example.com/',
+        headers: {},
+        body: ''
+      })
+
+      # Execute
+      described_class.call(webhook) do
+        Typhoeus.post(webhook.url)
+      end
+
+      # Verify
+      delivery = Delivery.last
+      expect(delivery.status).to eq('delivered')
+    end
+  end
+
+  context 'when the response times out' do
+    it 'should record a status of `timed_out`' do
+      # Prepare
+      stub_request(:post, 'example.com').to_timeout
+
+      webhook = Webhook.create!({
+        identifier: SecureRandom.uuid,
+        url: 'http://example.com/',
+        headers: {},
+        body: ''
+      })
+
+      # Execute
+      described_class.call(webhook) do
+        Typhoeus.post(webhook.url)
+      end
+
+      # Verify
+      delivery = Delivery.last
+      expect(delivery.status).to eq('timed_out')
+    end
+  end
+
+  context 'when unable to connect' do
+    it 'should record a status of `errored`' do
+      # Prepare
+      stub_request(:post, 'example.com').to_raise(Net::OpenTimeout)
+
+      webhook = Webhook.create!({
+        identifier: SecureRandom.uuid,
+        url: 'http://example.com/',
+        headers: {},
+        body: ''
+      })
+
+      # Execute
+      described_class.call(webhook) do
+        Typhoeus.post(webhook.url)
+      end
+
+      # Verify
+      delivery = Delivery.last
+      expect(delivery.status).to eq('errored')
+    end
+  end
+end

--- a/spec/support/test_models/delivery.rb
+++ b/spec/support/test_models/delivery.rb
@@ -1,0 +1,14 @@
+require_relative './base'
+
+module TestModels
+  class Delivery < Base
+    property :status
+    property :response_time_ms
+    property :response_status_code
+    property :response_headers
+    property :response_body
+
+    # associations
+    belongs_to :webhook
+  end
+end

--- a/spec/support/test_models/webhook.rb
+++ b/spec/support/test_models/webhook.rb
@@ -6,5 +6,8 @@ module TestModels
     property :url
     property :headers
     property :body
+
+    # associations
+    has_many :deliveries
   end
 end

--- a/spec/workers/webhook_delivery_worker_spec.rb
+++ b/spec/workers/webhook_delivery_worker_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 RSpec.describe WebhookDeliveryWorker do
   describe '#perform' do
     it 'should be deliver the webhook' do
-      response = double(:response, success?: true)
-      delivery_service = class_spy('DeliverWebhook', call: response)
+      stub_request(:post, 'example.com').
+        to_return(body: 'okay!', status: 200)
 
       record = Webhook.create({
         identifier: SecureRandom.uuid,
@@ -13,13 +13,13 @@ RSpec.describe WebhookDeliveryWorker do
         body: 'Some plain text'
       })
 
-      result = described_class.new.perform(record.id, delivery_service: delivery_service)
+      result = described_class.new.perform(record.id)
 
       aggregate_failures do
         # successful responses should return truthy
         expect(result).to be_truthy
-        # the delivery service should have been called
-        expect(delivery_service).to have_received(:call)
+        # there should be a recorded delivery
+        expect(record.deliveries.size).to eq(1)
       end
     end
   end


### PR DESCRIPTION
Webhooks are now no longer purely sent, each time the background queue attempts to deliver the webhook, it'll record various information about the response.