### PR TITLE
Feature: HTTP Basic Auth support

### DIFF
--- a/app/resources/api/v1/webhook_resource.rb
+++ b/app/resources/api/v1/webhook_resource.rb
@@ -1,6 +1,18 @@
 class Api::V1::WebhookResource < JSONAPI::Resource
-  attributes :identifier, :url, :headers, :body
+  attributes :identifier, :url, :headers, :body, :auth
 
   # associations
   has_many :deliveries
+
+  def auth
+    {
+      username: _model.basic_auth_username,
+      password: _model.basic_auth_password
+    }.compact
+  end
+
+  def auth=(value)
+    _model.basic_auth_username = value[:username]
+    _model.basic_auth_password = value[:password]
+  end
 end

--- a/app/workers/webhook_delivery_worker.rb
+++ b/app/workers/webhook_delivery_worker.rb
@@ -12,7 +12,9 @@ class WebhookDeliveryWorker
       delivery_service.call({
         url: webhook.url,
         headers: webhook.headers,
-        body: webhook.body
+        body: webhook.body,
+        username: webhook.basic_auth_username,
+        password: webhook.basic_auth_password
       })
     end
     # return true or false to requeue failures

--- a/db/migrate/20170209210923_add_http_basic_auth_credentials_to_webhooks.rb
+++ b/db/migrate/20170209210923_add_http_basic_auth_credentials_to_webhooks.rb
@@ -1,0 +1,6 @@
+class AddHttpBasicAuthCredentialsToWebhooks < ActiveRecord::Migration[5.0]
+  def change
+    add_column :webhooks, :basic_auth_username, :string
+    add_column :webhooks, :basic_auth_password, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170206200008) do
+ActiveRecord::Schema.define(version: 20170209210923) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,12 +28,14 @@ ActiveRecord::Schema.define(version: 20170206200008) do
   end
 
   create_table "webhooks", force: :cascade do |t|
-    t.uuid     "identifier",              null: false
-    t.string   "url",                     null: false
-    t.jsonb    "headers",    default: {}, null: false
-    t.text     "body",                    null: false
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
+    t.uuid     "identifier",                       null: false
+    t.string   "url",                              null: false
+    t.jsonb    "headers",             default: {}, null: false
+    t.text     "body",                             null: false
+    t.datetime "created_at",                       null: false
+    t.datetime "updated_at",                       null: false
+    t.string   "basic_auth_username"
+    t.string   "basic_auth_password"
     t.index ["identifier"], name: "index_webhooks_on_identifier", unique: true, using: :btree
     t.index ["url"], name: "index_webhooks_on_url", using: :btree
   end

--- a/docs/api.md
+++ b/docs/api.md
@@ -45,7 +45,11 @@ Deliveries are attempted 3 times before the background queue will give up.
       "headers": {
         "Content-Type": "application/json"
       },
-      "body": "{\"key\":\"value\"}"
+      "body": "{\"key\":\"value\"}",
+      "auth": {
+        "username": "testuser001",
+        "password": "arandompassword"
+      }
     }
   }
 }

--- a/spec/integration/webhooks_api_v1_spec.rb
+++ b/spec/integration/webhooks_api_v1_spec.rb
@@ -38,6 +38,25 @@ RSpec.describe 'Webhooks API v1', type: :api do
     expect(record_b.id).to eq(record_a.id)
   end
 
+  specify 'creating a webhook should accept HTTP Basic Auth credentials' do
+    record = TestModels::Webhook.create({
+      identifier: SecureRandom.uuid,
+      url: 'http://example.com/',
+      headers: { 'Content-Type': 'text/plain' },
+      body: 'Some plain text',
+      auth: { username: 'test', password: 'password123' }
+    })
+
+    aggregate_failures do
+      expect(record).to be_persisted
+      expect(record.errors).to be_empty
+      expect(record.auth).to match({
+        username: 'test',
+        password: 'password123'
+      })
+    end
+  end
+
   specify 'reading a webhook after creation' do
     record = TestModels::Webhook.create({
       identifier: SecureRandom.uuid,

--- a/spec/support/test_models/webhook.rb
+++ b/spec/support/test_models/webhook.rb
@@ -6,6 +6,7 @@ module TestModels
     property :url
     property :headers
     property :body
+    property :auth
 
     # associations
     has_many :deliveries

--- a/spec/workers/webhook_delivery_worker_spec.rb
+++ b/spec/workers/webhook_delivery_worker_spec.rb
@@ -4,13 +4,16 @@ RSpec.describe WebhookDeliveryWorker do
   describe '#perform' do
     it 'should be deliver the webhook' do
       stub_request(:post, 'example.com').
+        with(basic_auth: ['test', 'password123']).
         to_return(body: 'okay!', status: 200)
 
       record = Webhook.create({
         identifier: SecureRandom.uuid,
         url: 'http://example.com/',
         headers: { 'Content-Type' => 'text/plain' },
-        body: 'Some plain text'
+        body: 'Some plain text',
+        basic_auth_username: 'test',
+        basic_auth_password: 'password123'
       })
 
       result = described_class.new.perform(record.id)


### PR DESCRIPTION
Adds support to the webhook API allowing HTTP Basic Auth credentials to be sent which will automatically be converted to an `Authorization` header upon delivery.