### PR TITLE
Feature: configurable retry limit

### DIFF
--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -3,10 +3,16 @@ class Webhook < ApplicationRecord
   has_many :deliveries
 
   # core webhook data cannot be modified once created
-  attr_readonly :identifier, :url, :headers, :body
+  attr_readonly :identifier, :url, :headers, :body, :retry_limit
 
   # validation
   validates :identifier, :url, presence: true
+
+  validates :retry_limit, numericality: {
+    greater_than_or_equal_to: 0,
+    less_than_or_equal_to: 10,
+    allow_blank: false
+  }
 
   # override save to allow for idempotent save
   def save(*)

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -3,7 +3,7 @@ class Webhook < ApplicationRecord
   has_many :deliveries
 
   # core webhook data cannot be modified once created
-  attr_readonly :identifier, :url, :headers, :body, :retry_limit
+  attr_readonly :identifier, :url, :headers, :body
 
   # validation
   validates :identifier, :url, presence: true

--- a/app/resources/api/v1/webhook_resource.rb
+++ b/app/resources/api/v1/webhook_resource.rb
@@ -1,5 +1,5 @@
 class Api::V1::WebhookResource < JSONAPI::Resource
-  attributes :identifier, :url, :headers, :body, :auth
+  attributes :identifier, :url, :headers, :body, :auth, :retry_limit
 
   # associations
   has_many :deliveries

--- a/app/workers/webhook_delivery_worker.rb
+++ b/app/workers/webhook_delivery_worker.rb
@@ -4,6 +4,11 @@ class WebhookDeliveryWorker
   include Sidekiq::Worker
   sidekiq_options queue: 'webhook_delivery', retry: 10, dead: false
 
+  def initialize(*)
+    super
+    @retry_count = -1
+  end
+
   def perform(webhook_id, delivery_service: DeliverWebhook, record_service: RecordWebhook)
     # load the record from the database
     webhook = Webhook.find(webhook_id)
@@ -26,6 +31,6 @@ class WebhookDeliveryWorker
   end
 
   def retry_count
-    (@retry_count || -1) + 1
+    @retry_count + 1
   end
 end

--- a/app/workers/webhook_delivery_worker.rb
+++ b/app/workers/webhook_delivery_worker.rb
@@ -21,7 +21,9 @@ class WebhookDeliveryWorker
     response.success? || retry_count >= webhook.retry_limit
   end
 
-  attr_writer :retry_count
+  def retry_count=(value)
+    @retry_count = value
+  end
 
   def retry_count
     (@retry_count || -1) + 1

--- a/config/initializers/jsonapi.rb
+++ b/config/initializers/jsonapi.rb
@@ -1,0 +1,5 @@
+require 'jsonapi-resources'
+
+JSONAPI.configure do |config|
+  config.json_key_format = :underscored_key
+end

--- a/config/initializers/jsonapi.rb
+++ b/config/initializers/jsonapi.rb
@@ -1,5 +1,0 @@
-require 'jsonapi-resources'
-
-JSONAPI.configure do |config|
-  config.json_key_format = :underscored_key
-end

--- a/config/initializers/jsonapi_resources.rb
+++ b/config/initializers/jsonapi_resources.rb
@@ -1,0 +1,14 @@
+require 'jsonapi-resources'
+
+JSONAPI.configure do |config|
+  config.json_key_format = :underscored_key
+
+  # set some sensible limits
+  config.default_page_size = 10
+  config.maximum_page_size = 100
+
+  # add pagination by default
+  config.default_paginator = :offset
+  config.top_level_meta_include_record_count = true
+  config.top_level_meta_record_count_key = :record_count
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,5 +1,3 @@
-puts "SIDEKIQ INITIALIZER"
-
 require 'sidekiq'
 
 class SidekiqRetryCountMiddleware

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,19 @@
+puts "SIDEKIQ INITIALIZER"
+
+require 'sidekiq'
+
+class SidekiqRetryCountMiddleware
+  def call(worker, job, queue)
+    if worker.respond_to?(:retry_count)
+      worker.retry_count = (job['retry_count'] || -1) + 1
+    end
+
+    yield
+  end
+end
+
+Sidekiq.configure_server do |config|
+  config.server_middleware do |chain|
+    chain.add SidekiqRetryCountMiddleware
+  end
+end

--- a/db/migrate/20170209215133_add_retry_limit_to_webhooks.rb
+++ b/db/migrate/20170209215133_add_retry_limit_to_webhooks.rb
@@ -1,0 +1,5 @@
+class AddRetryLimitToWebhooks < ActiveRecord::Migration[5.0]
+  def change
+    add_column :webhooks, :retry_limit, :integer, default: 3, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170209210923) do
+ActiveRecord::Schema.define(version: 20170209215133) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,6 +36,7 @@ ActiveRecord::Schema.define(version: 20170209210923) do
     t.datetime "updated_at",                       null: false
     t.string   "basic_auth_username"
     t.string   "basic_auth_password"
+    t.integer  "retry_limit",         default: 3,  null: false
     t.index ["identifier"], name: "index_webhooks_on_identifier", unique: true, using: :btree
     t.index ["url"], name: "index_webhooks_on_url", using: :btree
   end

--- a/docs/api.md
+++ b/docs/api.md
@@ -49,7 +49,8 @@ Deliveries are attempted 3 times before the background queue will give up.
       "auth": {
         "username": "testuser001",
         "password": "arandompassword"
-      }
+      },
+      "retry_limit": 5
     }
   }
 }

--- a/spec/integration/webhooks_api_v1_spec.rb
+++ b/spec/integration/webhooks_api_v1_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe 'Webhooks API v1', type: :api do
       identifier: SecureRandom.uuid,
       url: 'http://example.com/',
       headers: { 'Content-Type': 'text/plain' },
-      body: 'Some plain text'
+      body: 'Some plain text',
+      retry_limit: 0
     })
 
     aggregate_failures do

--- a/spec/support/test_models/webhook.rb
+++ b/spec/support/test_models/webhook.rb
@@ -7,6 +7,7 @@ module TestModels
     property :headers
     property :body
     property :auth
+    property :retry_limit
 
     # associations
     has_many :deliveries


### PR DESCRIPTION
Allows the client to define how many times a given webhook should be retried should it fail to be delivered the first time, must be between 0 and 10 retries.