### PR TITLE
Feature: custom webhook timeouts

### DIFF
--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -11,6 +11,14 @@ class Webhook < ApplicationRecord
   validates :retry_limit, numericality: {
     greater_than_or_equal_to: 0,
     less_than_or_equal_to: 10,
+    only_integer: true,
+    allow_blank: false
+  }
+
+  validates :timeout, numericality: {
+    greater_than_or_equal_to: 1,
+    less_than_or_equal_to: 60,
+    only_integer: true,
     allow_blank: false
   }
 

--- a/app/resources/api/v1/webhook_resource.rb
+++ b/app/resources/api/v1/webhook_resource.rb
@@ -1,5 +1,5 @@
 class Api::V1::WebhookResource < JSONAPI::Resource
-  attributes :identifier, :url, :headers, :body, :auth, :retry_limit
+  attributes :identifier, :url, :headers, :body, :auth, :retry_limit, :timeout
 
   # associations
   has_many :deliveries

--- a/app/workers/webhook_delivery_worker.rb
+++ b/app/workers/webhook_delivery_worker.rb
@@ -19,7 +19,8 @@ class WebhookDeliveryWorker
         headers: webhook.headers,
         body: webhook.body,
         username: webhook.basic_auth_username,
-        password: webhook.basic_auth_password
+        password: webhook.basic_auth_password,
+        timeout: webhook.timeout
       })
     end
     # return true if successful or we've exhausted the retry limit

--- a/db/migrate/20170210153013_add_timeout_to_webhooks.rb
+++ b/db/migrate/20170210153013_add_timeout_to_webhooks.rb
@@ -1,0 +1,5 @@
+class AddTimeoutToWebhooks < ActiveRecord::Migration[5.0]
+  def change
+    add_column :webhooks, :timeout, :integer, default: 5, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170209215133) do
+ActiveRecord::Schema.define(version: 20170210153013) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,6 +37,7 @@ ActiveRecord::Schema.define(version: 20170209215133) do
     t.string   "basic_auth_username"
     t.string   "basic_auth_password"
     t.integer  "retry_limit",         default: 3,  null: false
+    t.integer  "timeout",             default: 5,  null: false
     t.index ["identifier"], name: "index_webhooks_on_identifier", unique: true, using: :btree
     t.index ["url"], name: "index_webhooks_on_url", using: :btree
   end

--- a/docs/api.md
+++ b/docs/api.md
@@ -32,6 +32,9 @@ Deliveries are attempted 3 times before the background queue will give up.
 * `url` – string, required
 * `headers` – object (key-value pairs), optional
 * `body` – string, required
+* `auth` – object (`username` / `password` keys), optional
+* `retry_limit` – integer, optional, min: 0, max: 10, default: 3
+* `timeout` – integer, optional, min: 1, max: 60, default: 5
 
 ##### Example Body
 
@@ -50,7 +53,8 @@ Deliveries are attempted 3 times before the background queue will give up.
         "username": "testuser001",
         "password": "arandompassword"
       },
-      "retry_limit": 5
+      "retry_limit": 5,
+      "timeout": 5
     }
   }
 }

--- a/spec/integration/webhooks_api_v1_spec.rb
+++ b/spec/integration/webhooks_api_v1_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe 'Webhooks API v1', type: :api do
       url: 'http://example.com/',
       headers: { 'Content-Type': 'text/plain' },
       body: 'Some plain text',
-      retry_limit: 0
+      retry_limit: 0,
+      timeout: 1
     })
 
     aggregate_failures do

--- a/spec/support/test_models/webhook.rb
+++ b/spec/support/test_models/webhook.rb
@@ -8,6 +8,7 @@ module TestModels
     property :body
     property :auth
     property :retry_limit
+    property :timeout
 
     # associations
     has_many :deliveries


### PR DESCRIPTION
Added timeout attribute for webhooks allowing users to define a custom timeout on specific webhooks, minimum 1 second, maximum 60 seconds, with a default of 5 seconds.