### PR TITLE
Feature: HTTP proxy support

### DIFF
--- a/app/resources/api/v1/webhook_resource.rb
+++ b/app/resources/api/v1/webhook_resource.rb
@@ -1,6 +1,6 @@
 class Api::V1::WebhookResource < JSONAPI::Resource
   attributes :identifier, :url, :headers, :body, :auth, :retry_limit, :timeout,
-    :status
+    :status, :proxy
 
   # associations
   has_many :deliveries
@@ -25,5 +25,23 @@ class Api::V1::WebhookResource < JSONAPI::Resource
   def auth=(value)
     _model.basic_auth_username = value[:username]
     _model.basic_auth_password = value[:password]
+  end
+
+  def proxy
+    if _model.proxy_enabled? && _model.proxy_url
+      _model.proxy_url
+    else
+      _model.proxy_enabled?
+    end
+  end
+
+  def proxy=(value)
+    if value.kind_of?(String)
+      _model.proxy_url = value
+      _model.proxy_enabled = true
+    else
+      _model.proxy_url = nil
+      _model.proxy_enabled = !!value
+    end
   end
 end

--- a/app/resources/api/v1/webhook_resource.rb
+++ b/app/resources/api/v1/webhook_resource.rb
@@ -10,11 +10,6 @@ class Api::V1::WebhookResource < JSONAPI::Resource
     super - [:status]
   end
 
-  # prevent setting of status
-  def self.updatable_fields(context)
-    super - [:status]
-  end
-
   def auth
     {
       username: _model.basic_auth_username,

--- a/app/services/webhooks/deliver.rb
+++ b/app/services/webhooks/deliver.rb
@@ -2,19 +2,31 @@ require 'typhoeus'
 
 # this module performs the transmission of a HTTP call
 module Webhooks
+  GLOBAL_HTTP_PROXY_URL = (ENV['HTTP_PROXY_URL'] || ENV['QUOTAGUARDSTATIC_URL'] || ENV['FIXIE_URL']).freeze
+
   module Deliver
-    def self.call(url:, headers:, body:, timeout: 5, username: nil, password: nil)
+    def self.call(webhook)
       # if we have HTTP Basic Auth username / password, pass them
-      if username || password
-        userpwd = "#{username}:#{password}"
+      if webhook.basic_auth_username || webhook.basic_auth_password
+        userpwd = "#{webhook.basic_auth_username}:#{webhook.basic_auth_password}"
+      end
+
+      # if the webhook should be sent via a custom HTTP proxy
+      if webhook.proxy_url.present?
+        proxy = webhook.proxy_url
+      # if the webhook should be sent via the system HTTP proxy
+      elsif webhook.proxy_enabled?
+        proxy = GLOBAL_HTTP_PROXY_URL
       end
 
       # make the HTTP call
-      Typhoeus.post url, headers: headers,
-                         userpwd: userpwd,
-                         body: body,
-                         timeout: timeout,
-                         accept_encoding: 'gzip'
+      Typhoeus.post webhook.url,
+        headers: webhook.headers,
+        userpwd: userpwd,
+        body: webhook.body,
+        timeout: webhook.timeout || 5,
+        accept_encoding: 'gzip',
+        proxy: proxy
     end
   end
 end

--- a/app/workers/webhook_delivery_worker.rb
+++ b/app/workers/webhook_delivery_worker.rb
@@ -14,14 +14,7 @@ class WebhookDeliveryWorker
     webhook = Webhook.find(webhook_id)
     # make the HTTP call
     response = record_service.call(webhook) do
-      delivery_service.call({
-        url: webhook.url,
-        headers: webhook.headers,
-        body: webhook.body,
-        username: webhook.basic_auth_username,
-        password: webhook.basic_auth_password,
-        timeout: webhook.timeout
-      })
+      delivery_service.call(webhook)
     end
     # return true if successful or we've exhausted the retry limit
     response.success? || retry_count >= webhook.retry_limit

--- a/db/migrate/20170218103954_add_proxy_to_webhooks.rb
+++ b/db/migrate/20170218103954_add_proxy_to_webhooks.rb
@@ -1,0 +1,6 @@
+class AddProxyToWebhooks < ActiveRecord::Migration[5.0]
+  def change
+    add_column :webhooks, :proxy_enabled, :boolean, null: false, default: false
+    add_column :webhooks, :proxy_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170216180612) do
+ActiveRecord::Schema.define(version: 20170218103954) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,8 @@ ActiveRecord::Schema.define(version: 20170216180612) do
     t.integer  "retry_limit",         default: 3,        null: false
     t.integer  "timeout",             default: 5,        null: false
     t.string   "status",              default: "queued", null: false
+    t.boolean  "proxy_enabled",       default: false,    null: false
+    t.string   "proxy_url"
     t.index ["identifier"], name: "index_webhooks_on_identifier", unique: true, using: :btree
     t.index ["url"], name: "index_webhooks_on_url", using: :btree
   end

--- a/docs/api.md
+++ b/docs/api.md
@@ -42,6 +42,7 @@ Deliveries are attempted 3 times before the background queue will give up.
 * `auth` – object (`username` / `password` keys), optional
 * `retry_limit` – integer, optional, min: 0, max: 10, default: 3
 * `timeout` – integer, optional, min: 1, max: 60, default: 5
+* `proxy` – boolean / url, optional, default: false
 
 ##### Example Body
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -44,6 +44,8 @@ Deliveries are attempted 3 times before the background queue will give up.
 * `timeout` – integer, optional, min: 1, max: 60, default: 5
 * `proxy` – boolean / url, optional, default: false
 
+Note: if `proxy` is set to true, it will use the system HTTP Proxy, which will be loaded from `ENV['QUOTAGUARDSTATIC_URL']`, `ENV['FIXIE_URL']` (allowing you to simply install either addon via Heroku), or `ENV['HTTP_PROXY_URL']` if you wish to use something custom.
+
 ##### Example Body
 
 ```json

--- a/spec/services/webhooks/deliver_spec.rb
+++ b/spec/services/webhooks/deliver_spec.rb
@@ -1,13 +1,18 @@
-require 'spec_helper'
+require 'rails_helper'
 require './app/services/webhooks/deliver'
 
 RSpec.describe Webhooks::Deliver do
   it 'should make HTTP calls with the given options' do
+    # Prepare
     stub_request(:post, 'www.example.com').
       to_return(body: 'okay!', status: 200)
 
-    response = described_class.call(url: 'www.example.com', headers: {}, body: '')
+    webhook = Webhook.new(url: 'www.example.com', headers: {}, body: '')
 
+    # Execute
+    response = described_class.call(webhook)
+
+    # Verify
     aggregate_failures do
       expect(response).to be_success
       expect(response.body).to eq('okay!')
@@ -15,6 +20,7 @@ RSpec.describe Webhooks::Deliver do
   end
 
   it 'should allow HTTP Basic Auth to be specified' do
+    # Prepare
     stub_request(:post, 'www.example.com').
       to_return(status: 401)
 
@@ -22,12 +28,31 @@ RSpec.describe Webhooks::Deliver do
       with(basic_auth: ['user', 'pass']).
       to_return(status: 200)
 
-    response_a = described_class.call(url: 'www.example.com', headers: {}, body: '')
-    response_b = described_class.call(url: 'www.example.com', headers: {}, body: '', username: 'user', password: 'pass')
+    webhook_a = Webhook.new(url: 'www.example.com', headers: {}, body: '')
+    webhook_b = Webhook.new(url: 'www.example.com', headers: {}, body: '', basic_auth_username: 'user', basic_auth_password: 'pass')
 
+    # Execute
+    response_a = described_class.call(webhook_a)
+    response_b = described_class.call(webhook_b)
+
+    # Verify
     aggregate_failures do
       expect(response_a.code).to eq(401)
       expect(response_b.code).to eq(200)
     end
+  end
+
+  it 'should allow a HTTP proxy to be specified' do
+    # Prepare
+    stub_request(:post, 'www.example.com').
+      to_return(status: 200)
+
+    webhook = Webhook.new(url: 'www.example.com', headers: {}, body: '', proxy_enabled: true, proxy_url: 'http://someproxy.org/')
+
+    # Execute
+    response = described_class.call(webhook)
+
+    # Verify
+    expect(response.code).to eq(200)
   end
 end

--- a/spec/support/test_models/webhook.rb
+++ b/spec/support/test_models/webhook.rb
@@ -10,6 +10,7 @@ module TestModels
     property :retry_limit
     property :timeout
     property :status
+    property :proxy
 
     # associations
     has_many :deliveries


### PR DESCRIPTION
Introduces a `proxy` attribute to the webhook resource, allowing either enabling of the system proxy (passing `true`) or a custom proxy (passing a URL string).

The system HTTP proxy will be loaded from `ENV['QUOTAGUARDSTATIC_URL']`, `ENV['FIXIE_URL']` (allowing you to simply install either addon via Heroku), or `ENV['HTTP_PROXY_URL']` if you wish to use something custom.