### PR TITLE
Feature: request signing

### DIFF
--- a/app/resources/api/v1/webhook_resource.rb
+++ b/app/resources/api/v1/webhook_resource.rb
@@ -1,6 +1,6 @@
 class Api::V1::WebhookResource < JSONAPI::Resource
   attributes :identifier, :url, :headers, :body, :auth, :retry_limit, :timeout,
-    :status, :proxy
+    :status, :proxy, :signatures
 
   # associations
   has_many :deliveries

--- a/app/services/webhooks/sign.rb
+++ b/app/services/webhooks/sign.rb
@@ -1,0 +1,27 @@
+require 'openssl'
+
+module Webhooks
+  module Sign
+    ALGORITHMS = {
+      'hmac-sha1':   'SHA1',
+      'hmac-sha256': 'SHA256',
+      'hmac-sha384': 'SHA384',
+      'hmac-sha512': 'SHA512',
+      'hmac-md5':    'MD5'
+    }.freeze
+
+    def self.call(webhook)
+      webhook.signatures.each do |signature|
+        webhook.headers[signature['header']] = hash_for(
+          body: webhook.body,
+          shared_secret: signature['shared_secret'],
+          algorithm: signature['algorithm']
+        )
+      end
+    end
+
+    def self.hash_for(shared_secret:, body:, algorithm:)
+      OpenSSL::HMAC.hexdigest(ALGORITHMS.fetch(algorithm.to_sym), shared_secret, body)
+    end
+  end
+end

--- a/app/workers/webhook_delivery_worker.rb
+++ b/app/workers/webhook_delivery_worker.rb
@@ -9,11 +9,12 @@ class WebhookDeliveryWorker
     @retry_count = -1
   end
 
-  def perform(webhook_id, delivery_service: Webhooks::Deliver, record_service: Webhooks::RecordTransmission)
+  def perform(webhook_id, delivery_service: Webhooks::Deliver, record_service: Webhooks::RecordTransmission, sign_service: Webhooks::Sign)
     # load the record from the database
     webhook = Webhook.find(webhook_id)
     # make the HTTP call
     response = record_service.call(webhook) do
+      sign_service.call(webhook)
       delivery_service.call(webhook)
     end
     # return true if successful or we've exhausted the retry limit

--- a/db/migrate/20170218141431_add_signatures_to_webhooks.rb
+++ b/db/migrate/20170218141431_add_signatures_to_webhooks.rb
@@ -1,0 +1,5 @@
+class AddSignaturesToWebhooks < ActiveRecord::Migration[5.0]
+  def change
+    add_column :webhooks, :signatures, :jsonb, null: false, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170218103954) do
+ActiveRecord::Schema.define(version: 20170218141431) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,6 +41,7 @@ ActiveRecord::Schema.define(version: 20170218103954) do
     t.string   "status",              default: "queued", null: false
     t.boolean  "proxy_enabled",       default: false,    null: false
     t.string   "proxy_url"
+    t.jsonb    "signatures",          default: [],       null: false
     t.index ["identifier"], name: "index_webhooks_on_identifier", unique: true, using: :btree
     t.index ["url"], name: "index_webhooks_on_url", using: :btree
   end

--- a/docs/api.md
+++ b/docs/api.md
@@ -43,8 +43,11 @@ Deliveries are attempted 3 times before the background queue will give up.
 * `retry_limit` – integer, optional, min: 0, max: 10, default: 3
 * `timeout` – integer, optional, min: 1, max: 60, default: 5
 * `proxy` – boolean / url, optional, default: false
+* `signatures` - array of objects, optional, default: empty
 
 Note: if `proxy` is set to true, it will use the system HTTP Proxy, which will be loaded from `ENV['QUOTAGUARDSTATIC_URL']`, `ENV['FIXIE_URL']` (allowing you to simply install either addon via Heroku), or `ENV['HTTP_PROXY_URL']` if you wish to use something custom.
+
+Note 2: for the algorithm in `signatures`, the supported values are `hmac-sha1`, `hmac-sha256`, `hmac-sha384`, `hmac-sha512`, `hmac-md5`.
 
 ##### Example Body
 
@@ -64,7 +67,14 @@ Note: if `proxy` is set to true, it will use the system HTTP Proxy, which will b
         "password": "arandompassword"
       },
       "retry_limit": 5,
-      "timeout": 5
+      "timeout": 5,
+      "signatures": [
+        {
+          "header": "X-Signature",
+          "shared_secret": "secret",
+          "algorithm": "hmac-sha1"
+        }
+      ]
     }
   }
 }

--- a/spec/services/webhooks/sign_spec.rb
+++ b/spec/services/webhooks/sign_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+require './app/services/webhooks/sign'
+
+RSpec.describe Webhooks::Sign do
+  it 'should update the headers with the signatures' do
+    webhook = Webhook.new(url: 'www.example.com', headers: {}, body: 'something', signatures: [
+      { shared_secret: 'secret', header: 'X-Signature', algorithm: 'hmac-sha1' }
+    ])
+
+    # Execute
+    described_class.call(webhook)
+
+    # Verify
+    expect(webhook.headers).to_not be_empty
+    expect(webhook.headers['X-Signature']).to eq('889b4bc00e8a5d6b05c3cb47db58217cac788526')
+  end
+end


### PR DESCRIPTION
This PR introduces the ability to define a set of signatures to apply as headers, e.g.

```json
[
  {
    "header": "X-Signature",
    "algorithm": "hmac-256",
    "shared_secret": "some_secret"
  }
]
```

The algorithm can be one of: `hmac-sha1`, `hmac-sha256`, `hmac-sha384`, `hmac-sha512`, `hmac-md5`.