### PR TITLE
Feature: event source

### DIFF
--- a/app/resources/api/v1/webhook_resource.rb
+++ b/app/resources/api/v1/webhook_resource.rb
@@ -1,6 +1,6 @@
 class Api::V1::WebhookResource < JSONAPI::Resource
   attributes :identifier, :url, :headers, :body, :auth, :retry_limit, :timeout,
-    :status, :proxy, :signatures
+    :status, :proxy, :signatures, :event_source
 
   # associations
   has_many :deliveries

--- a/db/migrate/20170220181043_add_event_source_to_webhooks.rb
+++ b/db/migrate/20170220181043_add_event_source_to_webhooks.rb
@@ -1,0 +1,5 @@
+class AddEventSourceToWebhooks < ActiveRecord::Migration[5.0]
+  def change
+    add_column :webhooks, :event_source, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170218141431) do
+ActiveRecord::Schema.define(version: 20170220181043) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,6 +42,7 @@ ActiveRecord::Schema.define(version: 20170218141431) do
     t.boolean  "proxy_enabled",       default: false,    null: false
     t.string   "proxy_url"
     t.jsonb    "signatures",          default: [],       null: false
+    t.jsonb    "event_source"
     t.index ["identifier"], name: "index_webhooks_on_identifier", unique: true, using: :btree
     t.index ["url"], name: "index_webhooks_on_url", using: :btree
   end

--- a/docs/api.md
+++ b/docs/api.md
@@ -44,6 +44,7 @@ Deliveries are attempted 3 times before the background queue will give up.
 * `timeout` – integer, optional, min: 1, max: 60, default: 5
 * `proxy` – boolean / url, optional, default: false
 * `signatures` - array of objects, optional, default: empty
+* `event_source` - object, optional
 
 Note: if `proxy` is set to true, it will use the system HTTP Proxy, which will be loaded from `ENV['QUOTAGUARDSTATIC_URL']`, `ENV['FIXIE_URL']` (allowing you to simply install either addon via Heroku), or `ENV['HTTP_PROXY_URL']` if you wish to use something custom.
 
@@ -74,7 +75,12 @@ Note 2: for the algorithm in `signatures`, the supported values are `hmac-sha1`,
           "shared_secret": "secret",
           "algorithm": "hmac-sha1"
         }
-      ]
+      ],
+      "event_source": {
+        "event": "object_created",
+        "object_type": "record",
+        "object_id": 123
+      }
     }
   }
 }

--- a/spec/integration/webhooks_api_v1_spec.rb
+++ b/spec/integration/webhooks_api_v1_spec.rb
@@ -9,7 +9,12 @@ RSpec.describe 'Webhooks API v1', type: :api do
       headers: { 'Content-Type': 'text/plain' },
       body: 'Some plain text',
       retry_limit: 0,
-      timeout: 1
+      timeout: 1,
+      event_source: {
+        event: 'test',
+        object_id: 123,
+        object_type: 'Type'
+      }
     })
 
     aggregate_failures do

--- a/spec/support/test_models/webhook.rb
+++ b/spec/support/test_models/webhook.rb
@@ -11,6 +11,8 @@ module TestModels
     property :timeout
     property :status
     property :proxy
+    property :signatures
+    property :event_source
 
     # associations
     has_many :deliveries


### PR DESCRIPTION
Fixes #15.

Introduces an `event_source` attribute to the webhook resource, allowing people to attach any attribution to the webhook for where it came from.