### PR TITLE
Feature: persisted delivery attempt count

### DIFF
--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -42,6 +42,6 @@ class Webhook < ApplicationRecord
   end
 
   def can_retry?
-    attempt_count >= attempt_limit
+    attempt_count < attempt_limit
   end
 end

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -8,7 +8,7 @@ class Webhook < ApplicationRecord
   # validation
   validates :identifier, :url, presence: true
 
-  validates :retry_limit, numericality: {
+  validates :attempt_limit, numericality: {
     greater_than_or_equal_to: 0,
     less_than_or_equal_to: 10,
     only_integer: true,
@@ -39,5 +39,9 @@ class Webhook < ApplicationRecord
     else
       super(validate: false)
     end
+  end
+
+  def can_retry?
+    attempt_count >= attempt_limit
   end
 end

--- a/app/resources/api/v1/webhook_resource.rb
+++ b/app/resources/api/v1/webhook_resource.rb
@@ -1,13 +1,13 @@
 class Api::V1::WebhookResource < JSONAPI::Resource
-  attributes :identifier, :url, :headers, :body, :auth, :retry_limit, :timeout,
-    :status, :proxy, :signatures, :event_source
+  attributes :identifier, :url, :headers, :body, :auth, :timeout,
+    :status, :proxy, :signatures, :event_source, :attempt_count, :attempt_limit
 
   # associations
   has_many :deliveries
 
   # prevent setting of status
   def self.creatable_fields(context)
-    super - [:status]
+    super - [:status, :attempt_count]
   end
 
   def auth

--- a/app/services/webhooks/calculate_status.rb
+++ b/app/services/webhooks/calculate_status.rb
@@ -7,7 +7,7 @@ module Webhooks
         'queued'
       elsif deliveries.any?(&:successful?)
         'delivered'
-      elsif deliveries.size >= webhook.retry_limit
+      elsif webhook.attempt_count >= webhook.attempt_limit
         'failed'
       else
         'retrying'

--- a/app/services/webhooks/calculate_status.rb
+++ b/app/services/webhooks/calculate_status.rb
@@ -7,7 +7,7 @@ module Webhooks
         'queued'
       elsif deliveries.any?(&:successful?)
         'delivered'
-      elsif webhook.attempt_count >= webhook.attempt_limit
+      elsif !webhook.can_retry?
         'failed'
       else
         'retrying'

--- a/app/workers/webhook_delivery_worker.rb
+++ b/app/workers/webhook_delivery_worker.rb
@@ -4,28 +4,19 @@ class WebhookDeliveryWorker
   include Sidekiq::Worker
   sidekiq_options queue: 'webhook_delivery', retry: 10, dead: false
 
-  def initialize(*)
-    super
-    @retry_count = -1
-  end
-
   def perform(webhook_id, delivery_service: Webhooks::Deliver, record_service: Webhooks::RecordTransmission, sign_service: Webhooks::Sign)
-    # load the record from the database
-    webhook = Webhook.find(webhook_id)
-    # make the HTTP call
-    response = record_service.call(webhook) do
-      sign_service.call(webhook)
-      delivery_service.call(webhook)
+    Webhook.connection_pool.with_connection do |conn|
+      # load the record from the database
+      webhook = Webhook.find(webhook_id)
+      # increment the attempt count
+      webhook.increment!(:attempt_count)
+      # make the HTTP call
+      response = record_service.call(webhook) do
+        sign_service.call(webhook)
+        delivery_service.call(webhook)
+      end
+      # return true if successful or we've exhausted the attempts limit
+      response.success? || !webhook.can_retry?
     end
-    # return true if successful or we've exhausted the retry limit
-    response.success? || retry_count >= webhook.retry_limit
-  end
-
-  def retry_count=(value)
-    @retry_count = value
-  end
-
-  def retry_count
-    @retry_count + 1
   end
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,15 +1,5 @@
 require 'sidekiq'
 
-class SidekiqRetryCountMiddleware
-  def call(worker, job, queue)
-    if worker.respond_to?(:retry_count)
-      worker.retry_count = (job['retry_count'] || -1) + 1
-    end
-
-    yield
-  end
-end
-
 class SidekiqGlobalListenersMiddleware
   def call(worker, job, queue)
     SubscribeGlobalListeners.call do
@@ -20,7 +10,6 @@ end
 
 Sidekiq.configure_server do |config|
   config.server_middleware do |chain|
-    chain.add SidekiqRetryCountMiddleware
     chain.add SidekiqGlobalListenersMiddleware
   end
 end

--- a/db/migrate/20170220184551_add_attempt_count_to_webhooks.rb
+++ b/db/migrate/20170220184551_add_attempt_count_to_webhooks.rb
@@ -1,0 +1,6 @@
+class AddAttemptCountToWebhooks < ActiveRecord::Migration[5.0]
+  def change
+    add_column :webhooks, :attempt_count, :integer, null: false, default: 0
+    rename_column :webhooks, :retry_limit, :attempt_limit
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170220181043) do
+ActiveRecord::Schema.define(version: 20170220184551) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,13 +36,14 @@ ActiveRecord::Schema.define(version: 20170220181043) do
     t.datetime "updated_at",                             null: false
     t.string   "basic_auth_username"
     t.string   "basic_auth_password"
-    t.integer  "retry_limit",         default: 3,        null: false
+    t.integer  "attempt_limit",       default: 3,        null: false
     t.integer  "timeout",             default: 5,        null: false
     t.string   "status",              default: "queued", null: false
     t.boolean  "proxy_enabled",       default: false,    null: false
     t.string   "proxy_url"
     t.jsonb    "signatures",          default: [],       null: false
     t.jsonb    "event_source"
+    t.integer  "attempt_count",       default: 0,        null: false
     t.index ["identifier"], name: "index_webhooks_on_identifier", unique: true, using: :btree
     t.index ["url"], name: "index_webhooks_on_url", using: :btree
   end

--- a/docs/api.md
+++ b/docs/api.md
@@ -31,7 +31,7 @@ Webhooks have a useful `status` attribute that will be one of the following:
 
 This endpoint allows you to submit a webhook to be queued for delivery. The endpoint is idempotent so if you submit a second webhook with the same `identifier` attribute, it will treat this as a duplicate record and return the original, without queuing a second delivery.
 
-Deliveries are attempted 3 times before the background queue will give up.
+Deliveries are attempted 3 times by default before the background queue will give up, though you can customise this by setting `attempt_limit`. You can also disable this by passing `0` as the value.
 
 ##### Attributes
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -40,7 +40,7 @@ Deliveries are attempted 3 times before the background queue will give up.
 * `headers` – object (key-value pairs), optional
 * `body` – string, required
 * `auth` – object (`username` / `password` keys), optional
-* `retry_limit` – integer, optional, min: 0, max: 10, default: 3
+* `attempt_limit` – integer, optional, min: 0, max: 10, default: 3
 * `timeout` – integer, optional, min: 1, max: 60, default: 5
 * `proxy` – boolean / url, optional, default: false
 * `signatures` - array of objects, optional, default: empty
@@ -67,7 +67,7 @@ Note 2: for the algorithm in `signatures`, the supported values are `hmac-sha1`,
         "username": "testuser001",
         "password": "arandompassword"
       },
-      "retry_limit": 5,
+      "attempt_limit": 5,
       "timeout": 5,
       "signatures": [
         {

--- a/spec/integration/webhooks_api_v1_spec.rb
+++ b/spec/integration/webhooks_api_v1_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Webhooks API v1', type: :api do
       url: 'http://example.com/',
       headers: { 'Content-Type': 'text/plain' },
       body: 'Some plain text',
-      retry_limit: 0,
+      attempt_limit: 0,
       timeout: 1,
       event_source: {
         event: 'test',

--- a/spec/models/webhook_spec.rb
+++ b/spec/models/webhook_spec.rb
@@ -23,4 +23,27 @@ RSpec.describe Webhook do
       expect(record_b.id).to eq(record_a.id)
     end
   end
+
+  describe '#can_retry?' do
+    context 'when the attempt count is less than the limit' do
+      it 'should return true' do
+        webhook = Webhook.new(attempt_count: 0, attempt_limit: 1)
+        expect(webhook.can_retry?).to eq(true)
+      end
+    end
+
+    context 'when the attempt count is equal to the limit' do
+      it 'should return false' do
+        webhook = Webhook.new(attempt_count: 1, attempt_limit: 1)
+        expect(webhook.can_retry?).to eq(false)
+      end
+    end
+
+    context 'when the attempt count is greater than the limit' do
+      it 'should return false' do
+        webhook = Webhook.new(attempt_count: 5, attempt_limit: 1)
+        expect(webhook.can_retry?).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/services/webhooks/calculate_status_spec.rb
+++ b/spec/services/webhooks/calculate_status_spec.rb
@@ -13,19 +13,19 @@ RSpec.describe Webhooks::CalculateStatus do
       end
     end
 
-    context 'when there are more unsuccessful deliveries than the retry limit' do
+    context 'when the attempt count has hit the limit' do
       it 'should return failed' do
         deliveries = [double('Delivery', successful?: false)]
-        webhook = double('Webhook', deliveries: deliveries, retry_limit: 0)
+        webhook = double('Webhook', deliveries: deliveries, attempt_count: 1, attempt_limit: 1)
 
         expect(described_class.call(webhook)).to eq('failed')
       end
     end
 
-    context 'when there are less unsuccessful deliveries than the retry limit' do
+    context 'when the attempt count has not hit the limit' do
       it 'should return retrying' do
         deliveries = [double('Delivery', successful?: false)]
-        webhook = double('Webhook', deliveries: deliveries, retry_limit: 10)
+        webhook = double('Webhook', deliveries: deliveries, attempt_count: 1, attempt_limit: 20)
 
         expect(described_class.call(webhook)).to eq('retrying')
       end
@@ -34,7 +34,7 @@ RSpec.describe Webhooks::CalculateStatus do
     context 'when there are no deliveries' do
       it 'should return queued' do
         deliveries = []
-        webhook = double('Webhook', deliveries: deliveries, retry_limit: 1)
+        webhook = double('Webhook', deliveries: deliveries, attempt_count: 0, attempt_limit: 1)
 
         expect(described_class.call(webhook)).to eq('queued')
       end

--- a/spec/services/webhooks/calculate_status_spec.rb
+++ b/spec/services/webhooks/calculate_status_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Webhooks::CalculateStatus do
     context 'when at least one delivery was successful' do
       it 'should return delivered' do
         deliveries = [double('Delivery', successful?: true)]
-        webhook = double('Webhook', deliveries: deliveries)
+        webhook = double('Webhook', deliveries: deliveries, can_retry?: false)
 
         expect(described_class.call(webhook)).to eq('delivered')
       end
@@ -16,7 +16,7 @@ RSpec.describe Webhooks::CalculateStatus do
     context 'when the attempt count has hit the limit' do
       it 'should return failed' do
         deliveries = [double('Delivery', successful?: false)]
-        webhook = double('Webhook', deliveries: deliveries, attempt_count: 1, attempt_limit: 1)
+        webhook = double('Webhook', deliveries: deliveries, can_retry?: false)
 
         expect(described_class.call(webhook)).to eq('failed')
       end
@@ -25,7 +25,7 @@ RSpec.describe Webhooks::CalculateStatus do
     context 'when the attempt count has not hit the limit' do
       it 'should return retrying' do
         deliveries = [double('Delivery', successful?: false)]
-        webhook = double('Webhook', deliveries: deliveries, attempt_count: 1, attempt_limit: 20)
+        webhook = double('Webhook', deliveries: deliveries, can_retry?: true)
 
         expect(described_class.call(webhook)).to eq('retrying')
       end
@@ -34,7 +34,7 @@ RSpec.describe Webhooks::CalculateStatus do
     context 'when there are no deliveries' do
       it 'should return queued' do
         deliveries = []
-        webhook = double('Webhook', deliveries: deliveries, attempt_count: 0, attempt_limit: 1)
+        webhook = double('Webhook', deliveries: deliveries, can_retry?: true)
 
         expect(described_class.call(webhook)).to eq('queued')
       end

--- a/spec/support/test_models/webhook.rb
+++ b/spec/support/test_models/webhook.rb
@@ -7,7 +7,8 @@ module TestModels
     property :headers
     property :body
     property :auth
-    property :retry_limit
+    property :attempt_count
+    property :attempt_limit
     property :timeout
     property :status
     property :proxy


### PR DESCRIPTION
Fixes: #12.

* Added an `attempt_count` attribute to the webhook resource
* Renamed `retry_limit` to `attempt_limit` to maintain consistency
* Added `Webhook#can_retry?` to provide a helper to whether more attempts are allowed